### PR TITLE
ODBC-6 Provide interface to enumerate tables (Datasets)

### DIFF
--- a/src/hpccdb.hpp
+++ b/src/hpccdb.hpp
@@ -233,7 +233,7 @@ public:
 
     //ws_sql calls
     bool        getHPCCDBSystemInfo();
-    bool        getTableSchema(const char * _tableFilter,  CTable **_table);
+    bool        getTableSchema(const char * _tableFilter, IArrayOf<CTable> &_tables);
     bool        executeSQL(const char * sql, const char * targetQuerySet, StringBuffer & sbErrors);
     bool        getMoreResults(const char * _wuid, const char * dsName, aindex_t _start, aindex_t _count, IPropertyTree ** _ppResultsTree, StringBuffer & _sbErrors);
     bool        executeStoredProcedure(const char * procName, const char * querySet);


### PR DESCRIPTION
Implement the ODBC interface that enables a client to enumerate the list
of tables, AKA HPCC Datasets. This involves a call to WsSQL GetDBMetaData()

Signed-off-by: William Whitehead <william.whitehead@lexisnexis.com>