### PR TITLE
ODBC-9 Provide interface to enumerate stored procedures

### DIFF
--- a/brand_hpcc_odbc32.bat
+++ b/brand_hpcc_odbc32.bat
@@ -1,4 +1,4 @@
-rem if "%PROGRESS_SDK_DIR%".==. set PROGRESS_SDK_DIR=C:\Program Files (x86)\Progress\DataDirect\oaodbclocal72
+if "%PROGRESS_SDK_DIR%".=="". set PROGRESS_SDK_DIR=C:\Program Files (x86)\Progress\DataDirect\oaodbclocal72
 
 @echo on
 @echo ==============================================================================

--- a/package_hpcc_odbc32.bat
+++ b/package_hpcc_odbc32.bat
@@ -1,6 +1,6 @@
-if "%PROGRESS_SDK_DIR%".==. set PROGRESS_SDK_DIR=C:\Program Files (x86)\Progress\DataDirect\oaodbclocal72
-if "%HPCCODBC_SRC_DIR%".==. set HPCCODBC_SRC_DIR=C:\hpcc\HPCC-ODBC
-if "%HPCC_BUILD_DIR%".==. set HPCC_BUILD_DIR=C:\hpcc\HPCC-Lib
+if "%PROGRESS_SDK_DIR%".=="". set PROGRESS_SDK_DIR=C:\Program Files (x86)\Progress\DataDirect\oaodbclocal72
+if "%HPCCODBC_SRC_DIR%".=="". set HPCCODBC_SRC_DIR=C:\hpcc\HPCC-ODBC
+if "%HPCC_BUILD_DIR%".=="". set HPCC_BUILD_DIR=C:\hpcc\HPCC-Lib
 
 @echo on
 @echo ------------------------------------------------------------------------------

--- a/src/hpcc_drv.cpp
+++ b/src/hpcc_drv.cpp
@@ -1089,7 +1089,35 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
             else
             {
                 tm_trace(hpcc_tm_Handle, UL_TM_MAJOR_EV, "HPCC_Conn:Dynamic Schema for all Procedures is being requested\n", ());
-                return DAM_FAILURE;
+                const IArrayOf<CMyQuerySet> * arrQuerySets = pConnDA->pHPCCdb->queryQuerySets();
+                ForEachItemIn(Idx, *arrQuerySets)//thor,hthor,roxie
+                {
+                    CMyQuerySet &qrySet = (CMyQuerySet&)arrQuerySets->item(Idx);
+                    ForEachItemIn(Idx2, *qrySet.queryQueries())
+                    {
+                        CMyQuerySetQuery &query = qrySet.queryQueries()->item(Idx2);
+                        StringBuffer procName;
+                        procName.setf("%s.%s",qrySet.queryName(), query.queryName());
+
+                        rc = dam_add_damobj_proc(pMemTree, // XM_Tree *    pMemTree,
+                            pList,                  // DAM_OBJ_LIST pList,
+                            pSearchObj,             // DAM_OBJ      pSearchObj,
+                            HPCC_CATALOG_NAME,      // char   *proc_qualifier,
+                            HPCC_USER_NAME,         // char   *proc_owner,
+                            (char*)procName.str(),  // char   *proc_name,
+                            (long)query.queryNumInputs(),// long   num_input_params,Not used at this time
+                            (long)DAMOBJ_NOTSET,    // long   num_output_params,Not used at this time
+                            (long)query.queryNumOutputDatasets(),// long   num_result_sets,
+                            SQL_PT_PROCEDURE,       // short  proc_type, does not have a return value.
+                            (char*)&query,          // char   *userdata,
+                            NULL);                  // char   *remarks
+                        if (rc != DAM_SUCCESS)
+                        {
+                            return DAM_FAILURE;
+                        }
+                    }
+                }
+                return DAM_SUCCESS;
             }
         }
         break;


### PR DESCRIPTION
The HPCC-ODBC connector needs to be able to enumerate HPCC Deployed Queries
and report them to the Progress Data Direct SDK as Stored Procedures. This
code implements the ability to enumerate them, and report to Progress

Signed-off-by: William Whitehead <william.whitehead@lexisnexis.com>