### PR TITLE
ODBC-11 Specify table owner to odbc metadata

### DIFF
--- a/src/hpcc_drv.cpp
+++ b/src/hpcc_drv.cpp
@@ -79,8 +79,8 @@ IP_SUPPORT_ARRAY    hpcc_support_array =
         0   /* Reserved for future use */
     };
 
-#define HPCC_QUALIFIER_NAME "SCHEMA"
-#define HPCC_CATALOG_NAME   "SCHEMA"
+#define HPCC_QUALIFIER_NAME "HPCC System"
+#define HPCC_CATALOG_NAME   "HPCC System"
 #define HPCC_USER_NAME      "HPCCUSER"   //table is managed by user(us)
 
 static int     bAllowSchemaSearchPattern = FALSE;
@@ -951,15 +951,15 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                 {
                     assertex(!_tables.empty());
                     CTable &table = _tables.item(0);
-                    if (hpcc_is_matching_table(pSearchTableObj, HPCC_QUALIFIER_NAME, HPCC_USER_NAME, (char*)table.queryName()))
+                    if (hpcc_is_matching_table(pSearchTableObj, HPCC_QUALIFIER_NAME, (char*)table.queryOwner(), (char*)table.queryName()))
                     {
                         rc = dam_add_damobj_table(
                             pMemTree,                   //XM_Tree *     pMemTree,
                             pList,                      //DAM_OBJ_LIST  pList,
                             pSearchObj,                 //DAM_OBJ       pSearchObj,
                             HPCC_QUALIFIER_NAME,        //char   *      table_qualifier,
-                            HPCC_USER_NAME,             //char   *      table_owner,
-                            (char*)table.queryName(),  //char   *      table_name,
+                            (char*)table.queryOwner(),  //char   *      table_owner,
+                            (char*)table.queryName(),   //char   *      table_name,
                             "TABLE",                    //char   *      table_type, (TABLE == managed by IP)
                             NULL,                       //char   *      table_path,
                             NULL,                       //char   *      table_userdata
@@ -992,7 +992,7 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                             pList,                     //DAM_OBJ_LIST  pList,
                             pSearchObj,                //DAM_OBJ       pSearchObj,
                             HPCC_QUALIFIER_NAME,       //char   *      table_qualifier,
-                            HPCC_USER_NAME,            //char   *      table_owner,
+                            (char*)table.queryOwner(), //char   *      table_owner,
                             (char*)table.queryName(),  //char   *      table_name,
                             "TABLE",                   //char   *      table_type, (TABLE == managed by IP)
                             NULL,                      //char   *      table_path,
@@ -1030,7 +1030,7 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                     for (aindex_t colIdx = 0; colIdx < numCols; colIdx++)//iterate over all columns in specified table
                     {
                         CColumn *col = table.queryColumn(colIdx);
-                        if (hpcc_is_matching_column(pSearchColumnObj, HPCC_QUALIFIER_NAME, HPCC_USER_NAME, (char*)table.queryName()))
+                        if (hpcc_is_matching_column(pSearchColumnObj, HPCC_QUALIFIER_NAME, (char*)table.queryOwner(), (char*)table.queryName()))
                         {
                             populateOAtypes(col);//map HPCC data types to OpenAccess dam_add_damobj_column types
                             rc = dam_add_damobj_column(
@@ -1038,7 +1038,7 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                                     pList,                  //DAM_OBJ_LIST pList,
                                     pSearchObj,             //DAM_OBJ      pSearchObj,
                                     HPCC_QUALIFIER_NAME,    //char   *     table_qualifier,
-                                    HPCC_USER_NAME,         //char   *     table_owner,
+                                    (char*)table.queryOwner(),//char   *     table_owner,
                                     (char*)table.queryName(),//char  *   table_name
                                     (char*)col->m_name.get(),//char   *     column_name,
                                     col->m_iXOType,         //short        data_type,

--- a/src/hpccdb.cpp
+++ b/src/hpccdb.cpp
@@ -334,7 +334,7 @@ bool HPCCdb::getTableSchema(const char * _tableFilter, IArrayOf<CTable> &_tables
         CHPCCTable &tableItem = (CHPCCTable &)tables.item(tableIdx);
         tm_trace(driver_tm_Hdle, UL_TM_F_TRACE, "HPCC_Conn:Found table '%s'\n", (tableItem.getName()));
         Owned<CTable> tblEntry;
-        tblEntry.setown(new CTable(tableItem.getName(), tableItem.getDescription()));
+        tblEntry.setown(new CTable(tableItem.getName(), tableItem.getDescription(), tableItem.getOwner()));
 #ifdef _WIN32
         OutputDebugString(tableItem.getName());OutputDebugString("\n");
 #endif

--- a/src/hpccdb.hpp
+++ b/src/hpccdb.hpp
@@ -63,14 +63,17 @@ class CTable : public CInterface, public IInterface
     StringAttr          m_name;
     StringAttr          m_description;
     IArrayOf<CColumn>   m_columns;
+    StringAttr          m_owner;
 
 public:
     IMPLEMENT_IINTERFACE;
-    CTable(const char * _name, const char * _description) : m_name(_name), m_description(_description) {}
+    CTable(const char * _name, const char * _description, const char * _owner) : m_name(_name), m_description(_description), m_owner(_owner) {}
     virtual ~CTable() {}
 
     const char * queryName()                    { return m_name.get(); }
     const char * queryDescription()             { return m_description.get(); }
+    const char * queryOwner()                   { return m_owner.get(); }
+
     void        addColumn(CColumn * _column)    { m_columns.append(*_column); }
     aindex_t    queryNumColumns()               { return m_columns.ordinality(); }
     CColumn *   queryColumn(aindex_t colNum)    { return (CColumn *)&m_columns.item(colNum); }//zero based column indices
@@ -112,12 +115,12 @@ public:
     void addOutputDatasetColumn(const char * datasetName, CColumn * _output)
     {
         if (0 == m_outputDatasets.ordinality())
-            m_outputDatasets.append(*(new CTable(datasetName,NULL)));//add new output dataset
+            m_outputDatasets.append(*(new CTable(datasetName,NULL,NULL)));//add new output dataset
         else
         {
             CTable & dataset = m_outputDatasets.item(m_outputDatasets.ordinality() - 1);
             if (0 != strcmp(datasetName, dataset.queryName()))
-                m_outputDatasets.append(*(new CTable(datasetName,NULL)));//add new output dataset
+                m_outputDatasets.append(*(new CTable(datasetName,NULL,NULL)));//add new output dataset
         }
         CTable & dataset = m_outputDatasets.item(m_outputDatasets.ordinality() - 1);
         dataset.addColumn(_output);


### PR DESCRIPTION
Currently table owner is hardcoded as HPCCUser. In reality it should
bo set from the WsSQL GetDBMetaData response

Signed-off-by: William Whitehead <william.whitehead@lexisnexis.com>