### PR TITLE
ODBC-14 Add error string to be reported to user

### DIFF
--- a/src/hpcc_drv.cpp
+++ b/src/hpcc_drv.cpp
@@ -125,7 +125,7 @@ int             OAIP_init(TM_ModuleCB tmHandle, XM_Tree *pMemTree, IP_HENV *phen
     tm_trace(hpcc_tm_Handle, UL_TM_F_TRACE, "HPCC_Conn:OAIP_init() has been called\n", ());//allocate the environment handle
     if(!(pEnvDA = (HPCC_ENV_DA *)xm_allocItem(pMemTree, sizeof(HPCC_ENV_DA), XM_NOFLAGS)))
     {
-        dam_addError(NULL, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_init : xm_allocItem failed");
+        dam_addError(NULL, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_init : internal error, xm_allocItem failed");
         return DAM_FAILURE;
     }
     pEnvDA->pMemTree = pMemTree;    //save the memory tree handle
@@ -254,7 +254,7 @@ int             OAIP_getSupport(IP_HDBC hdbc, int iSupportType,
     if (iSupportType  > sizeof(hpcc_support_array))
     {
         StringBuffer err;
-        err.setf("HPCC_Conn:OAIP_getSupport : iSupportType '%d' out of bounds", iSupportType);
+        err.setf("HPCC_Conn:OAIP_getSupport : internal error, iSupportType '%d' out of bounds", iSupportType);
         dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
         return DAM_FAILURE;
     }
@@ -282,7 +282,7 @@ int             OAIP_connect(DAM_HDBC dam_hdbc, IP_HENV henv,
     /* allocate the connection da */
     if(!(pConnDA = (HPCC_CONN_DA *)xm_allocItem(pMemTree, sizeof(HPCC_CONN_DA), XM_NOFLAGS)))
     {
-        dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_connect : xm_allocItem failed");
+        dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_connect : internal error, xm_allocItem failed");
         return DAM_FAILURE;
     }
 
@@ -372,7 +372,9 @@ int             OAIP_connect(DAM_HDBC dam_hdbc, IP_HENV henv,
         delete pConnDA->pHPCCdb;
 
         StringBuffer err;
-        err.setf("HPCC_Conn:OAIP_connect : Unable to connect to WsSQL on '%s:%s' as '%s'", wssqlIP.str(), wssqlPort.str(), sUserName);
+        err.setf("HPCC_Conn:OAIP_connect : Unable to connect to WsSQL on '%s:%s'", wssqlIP.str(), wssqlPort.str());
+        if (sUserName && *sUserName)
+            err.appendf(" as '%s'", sUserName);
         dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
 
         return DAM_FAILURE;
@@ -447,7 +449,7 @@ int             OAIP_execute(IP_HDBC hdbc,
     XM_Tree      *  pMemTree;
     DAM_HCOL        hcol;
 
-    tm_trace(hpcc_tm_Handle, UL_TM_F_TRACE, "HPCC_Conn:OAIP_execute() has been called", (0));
+    tm_trace(hpcc_tm_Handle, UL_TM_F_TRACE, "HPCC_Conn:OAIP_execute() has been called\n", (0));
 
     if(iStmtType != DAM_SELECT)
     {
@@ -458,7 +460,7 @@ int             OAIP_execute(IP_HDBC hdbc,
     pMemTree = dam_getMemTree(hstmt);/* get the memory tree to be used */
     if(!(pStmtDA = (HPCC_STMT_DA *)xm_allocItem(pMemTree, sizeof(HPCC_STMT_DA), XM_NOFLAGS)))/* allocate a new stmt */
     {
-        dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_execute : xm_allocItem failed");
+        dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_execute : internal error, xm_allocItem failed");
         return DAM_FAILURE;
     }
     /* initialize the StmtDA */
@@ -506,7 +508,7 @@ int             OAIP_execute(IP_HDBC hdbc,
         if (!pCol)
         {
             StringBuffer err;
-            err.setf("HPCC_Conn:OAIP_execute : Table '%s' Column '%s' not found", table.queryName(), sColName);
+            err.setf("HPCC_Conn:OAIP_execute : Table '%s', Column '%s' not found", table.queryName(), sColName);
             dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
             return DAM_FAILURE;
         }
@@ -586,7 +588,7 @@ int             OAIP_procedure(IP_HDBC hdbc, DAM_HSTMT hstmt, int iType, int *pi
     pMemTree = dam_getMemTree(hstmt);/* get the memory tree to be used */
     if(!(pStmtDA = (HPCC_STMT_DA *)xm_allocItem(pMemTree, sizeof(HPCC_STMT_DA), XM_NOFLAGS)))/* allocate a new stmt */
     {
-        dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_procedure : xm_allocItem failed");
+        dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_procedure : internal error, xm_allocItem failed");
         return DAM_FAILURE;
     }
 
@@ -658,7 +660,7 @@ int             OAIP_procedure(IP_HDBC hdbc, DAM_HSTMT hstmt, int iType, int *pi
                                      &iValLen); //Length of the return value
         if (iRetCode != DAM_SUCCESS)
         {
-            dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_procedure : dam_getValueToSet failed");
+            dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_procedure : internal error, dam_getValueToSet failed");
             return DAM_FAILURE;
         }
         if (0 == iParamNum)
@@ -956,7 +958,7 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                     DAM_OBJ_LIST pList,
                     DAM_OBJ pSearchObj)
 {
-    tm_trace(hpcc_tm_Handle, UL_TM_F_TRACE, "HPCC_Conn:OAIP_schema() has been called \n", ());
+    tm_trace(hpcc_tm_Handle, UL_TM_F_TRACE, "HPCC_Conn:OAIP_schema() has been called\n", ());
 
     int rc;
     HPCC_CONN_DA *pConnDA = (HPCC_CONN_DA *)hdbc;
@@ -1043,7 +1045,7 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
 
             if(pSearchColumnObj)
             {
-                tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV,"HPCC_Conn:Dynamic Schema for columns of table :(%s.%s.%s) is being requested. Column Schema requested with %s \n",
+                tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV,"HPCC_Conn:Dynamic Schema for columns of table :(%s.%s.%s) is being requested. Column Schema requested with %s\n",
                     (pSearchColumnObj->table_qualifier,pSearchColumnObj->table_owner,pSearchColumnObj->table_name,
                     dam_isSearchPatternObject(pSearchObj) ? "Pattern SearchObject" : "Non-Pattern SearchObject"));
 
@@ -1180,7 +1182,7 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                             NULL);                  // char   *remarks
                     if (rc != DAM_SUCCESS)
                     {
-                        dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_schema : dam_add_damobj_proc failed");
+                        dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_schema : internal error, dam_add_damobj_proc failed");
                         return DAM_FAILURE;
                     }
                 }
@@ -1238,7 +1240,7 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                 if (!pQuery)
                 {
                     StringBuffer err;
-                    err.setf("HPCC_Conn:OAIP_schema : Query '%s' not found in HPCC cache\n", pSearchProcColumnObj->name);
+                    err.setf("HPCC_Conn:OAIP_schema : Query '%s' not found", pSearchProcColumnObj->name);
                     dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
                     return DAM_FAILURE;
                 }

--- a/src/hpcc_drv.cpp
+++ b/src/hpcc_drv.cpp
@@ -125,6 +125,7 @@ int             OAIP_init(TM_ModuleCB tmHandle, XM_Tree *pMemTree, IP_HENV *phen
     tm_trace(hpcc_tm_Handle, UL_TM_F_TRACE, "HPCC_Conn:OAIP_init() has been called\n", ());//allocate the environment handle
     if(!(pEnvDA = (HPCC_ENV_DA *)xm_allocItem(pMemTree, sizeof(HPCC_ENV_DA), XM_NOFLAGS)))
     {
+        dam_addError(NULL, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_init : xm_allocItem failed");
         return DAM_FAILURE;
     }
     pEnvDA->pMemTree = pMemTree;    //save the memory tree handle
@@ -252,7 +253,9 @@ int             OAIP_getSupport(IP_HDBC hdbc, int iSupportType,
     HPCC_CONN_DA *      pConnDA = (HPCC_CONN_DA *)hdbc;
     if (iSupportType  > sizeof(hpcc_support_array))
     {
-        tm_trace(hpcc_tm_Handle, UL_TM_MAJOR_EV, "HPCC_Conn:OAIP_getSupport(): iSupportType out of bounds\n", (iSupportType));
+        StringBuffer err;
+        err.setf("HPCC_Conn:OAIP_getSupport : iSupportType '%d' out of bounds", iSupportType);
+        dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
         return DAM_FAILURE;
     }
     *pSupportExists = hpcc_support_array[iSupportType];
@@ -278,7 +281,10 @@ int             OAIP_connect(DAM_HDBC dam_hdbc, IP_HENV henv,
 
     /* allocate the connection da */
     if(!(pConnDA = (HPCC_CONN_DA *)xm_allocItem(pMemTree, sizeof(HPCC_CONN_DA), XM_NOFLAGS)))
+    {
+        dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_connect : xm_allocItem failed");
         return DAM_FAILURE;
+    }
 
     /* initialize the ConnDA */
     pConnDA->pMemTree = pMemTree;
@@ -364,7 +370,11 @@ int             OAIP_connect(DAM_HDBC dam_hdbc, IP_HENV henv,
     if (!pConnDA->pHPCCdb->getHPCCDBSystemInfo())
     {
         delete pConnDA->pHPCCdb;
-        tm_trace(hpcc_tm_Handle, UL_TM_PARM, "HPCC_Conn:OAIP_connect() failed, unable to connect to %s:wssql\n", (wssqlIP.str()));
+
+        StringBuffer err;
+        err.setf("HPCC_Conn:OAIP_connect : Unable to connect to WsSQL on '%s:%s' as '%s'", wssqlIP.str(), wssqlPort.str(), sUserName);
+        dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
+
         return DAM_FAILURE;
     }
 
@@ -389,6 +399,7 @@ int             OAIP_connectW(DAM_HDBC dam_hdbc, IP_HENV henv,
                                OAWCHAR *sCurrentCatalog, OAWCHAR *sIPProperties, OAWCHAR *sIPCustomProperties,
                                IP_HDBC *phdbc)
 {
+    dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_connectW : not supported");
     return DAM_FAILURE;
 }
 
@@ -440,14 +451,16 @@ int             OAIP_execute(IP_HDBC hdbc,
 
     if(iStmtType != DAM_SELECT)
     {
-        tm_trace(hpcc_tm_Handle, UL_TM_MINOR_EV, "HPCC_Conn:OAIP_execute Only SELECT statements supported", (0));
+        dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_execute : Only SELECT statements supported");
         return DAM_FAILURE;
     }
 
     pMemTree = dam_getMemTree(hstmt);/* get the memory tree to be used */
     if(!(pStmtDA = (HPCC_STMT_DA *)xm_allocItem(pMemTree, sizeof(HPCC_STMT_DA), XM_NOFLAGS)))/* allocate a new stmt */
+    {
+        dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_execute : xm_allocItem failed");
         return DAM_FAILURE;
-
+    }
     /* initialize the StmtDA */
     pStmtDA->pMemTree = pMemTree;
     pStmtDA->pConnDA = pConnDA;
@@ -461,7 +474,9 @@ int             OAIP_execute(IP_HDBC hdbc,
     pConnDA->pHPCCdb->clearOutputColumnDescriptors();
     if (_tables.empty())
     {
-        tm_trace(hpcc_tm_Handle, UL_TM_MINOR_EV, "HPCC_Conn:OAIP_execute Table '%s' not found", (pStmtDA->sTableName));
+        StringBuffer err;
+        err.setf("HPCC_Conn:OAIP_execute : Table '%s' not found", pStmtDA->sTableName);
+        dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
         return DAM_FAILURE;
     }
     assertex(!_tables.empty());
@@ -490,7 +505,9 @@ int             OAIP_execute(IP_HDBC hdbc,
         CColumn *pCol = table.queryColumn(iColNum);//find this hpcc CColumn descriptor
         if (!pCol)
         {
-            tm_trace(hpcc_tm_Handle, UL_TM_MINOR_EV, "HPCC_Conn:OAIP_execute Column '%s' not found", (sColName));
+            StringBuffer err;
+            err.setf("HPCC_Conn:OAIP_execute : Table '%s' Column '%s' not found", table.queryName(), sColName);
+            dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
             return DAM_FAILURE;
         }
 
@@ -568,7 +585,10 @@ int             OAIP_procedure(IP_HDBC hdbc, DAM_HSTMT hstmt, int iType, int *pi
 
     pMemTree = dam_getMemTree(hstmt);/* get the memory tree to be used */
     if(!(pStmtDA = (HPCC_STMT_DA *)xm_allocItem(pMemTree, sizeof(HPCC_STMT_DA), XM_NOFLAGS)))/* allocate a new stmt */
+    {
+        dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_procedure : xm_allocItem failed");
         return DAM_FAILURE;
+    }
 
     /* initialize the StmtDA */
     pStmtDA->pMemTree = pMemTree;
@@ -585,8 +605,12 @@ int             OAIP_procedure(IP_HDBC hdbc, DAM_HSTMT hstmt, int iType, int *pi
     CMyQuerySetQuery * pQuery = NULL;
     pQuery = pConnDA->pHPCCdb->queryStoredProcedure(pConnDA->pHPCCdb->queryCurrentQuerySet(), sProcName);//find specified stored procedure
     if (!pQuery)
+    {
+        StringBuffer err;
+        err.setf("HPCC_Conn:OAIP_procedure : Procedure '%s' not be found", sProcName);
+        dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
         return DAM_FAILURE;
-
+    }
     CTable *pTable = pQuery->queryOutputDataset(0);//wssql only supports single output dataset
     aindex_t numCols = pTable->queryNumColumns();
 
@@ -633,8 +657,10 @@ int             OAIP_procedure(IP_HDBC hdbc, DAM_HSTMT hstmt, int iType, int *pi
                                      &pVal,     //Reference to the value pointer being returned
                                      &iValLen); //Length of the return value
         if (iRetCode != DAM_SUCCESS)
+        {
+            dam_addError(hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_procedure : dam_getValueToSet failed");
             return DAM_FAILURE;
-
+        }
         if (0 == iParamNum)
             sqlBuff.append(" (");
         else
@@ -972,7 +998,9 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                 }
                 else
                 {
-                    tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV,"HPCC_Conn:Table not found/not supported '%s'\n",(pSearchTableObj->table_name));
+                    StringBuffer err;
+                    err.setf("HPCC_Conn:OAIP_schema : Table '%s' not found/not supported", pSearchTableObj->table_name);
+                    dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
                     return DAM_FAILURE;
                 }
             }
@@ -1061,7 +1089,9 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                 }
                 else
                 {
-                    tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV,"HPCC_Conn:Table not found/not supported '%s'\n",(pSearchColumnObj->table_name));
+                    StringBuffer err;
+                    err.setf("HPCC_Conn:OAIP_schema : Table '%s' not found/not supported", pSearchColumnObj->table_name);
+                    dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
                     return DAM_FAILURE;
                 }
             }
@@ -1146,16 +1176,19 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                             (long)DAMOBJ_NOTSET,    // long   num_output_params,Not used at this time
                             (long)pQuery->queryNumOutputDatasets(),// long   num_result_sets,
                             SQL_PT_PROCEDURE,       // short  proc_type, does not have a return value.
-                            (char*)pQuery,        // char   *userdata,
+                            (char*)pQuery,          // char   *userdata,
                             NULL);                  // char   *remarks
                     if (rc != DAM_SUCCESS)
                     {
+                        dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, "HPCC_Conn:OAIP_schema : dam_add_damobj_proc failed");
                         return DAM_FAILURE;
                     }
                 }
                 else
                 {
-                    tm_trace(hpcc_tm_Handle, UL_TM_MAJOR_EV, "HPCC_Conn:Query %s not found in HPCC cache\n", (pSearchProcObj->name));
+                    StringBuffer err;
+                    err.setf("HPCC_Conn:OAIP_schema : Query '%s' not found in HPCC cache\n", pSearchProcObj->name);
+                    dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
                     return DAM_FAILURE;
                 }
             }
@@ -1204,7 +1237,9 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                 CMyQuerySetQuery * pQuery = pConnDA->pHPCCdb->queryStoredProcedure(pConnDA->pHPCCdb->queryCurrentQuerySet(), pSearchProcColumnObj->name);//find specified stored procedure
                 if (!pQuery)
                 {
-                    tm_trace(hpcc_tm_Handle, UL_TM_MAJOR_EV, "HPCC_Conn:Query %s not found in HPCC cache\n", (pSearchProcColumnObj->name));
+                    StringBuffer err;
+                    err.setf("HPCC_Conn:OAIP_schema : Query '%s' not found in HPCC cache\n", pSearchProcColumnObj->name);
+                    dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
                     return DAM_FAILURE;
                 }
 
@@ -1242,7 +1277,9 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                     }
                     else
                     {
-                        tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV,"HPCC_Conn:Input column descriptor not found/not supported '%s'\n",(pSearchProcColumnObj->name));
+                        StringBuffer err;
+                        err.setf("HPCC_Conn:OAIP_schema : Input column descriptor '%s' not found/not supported",pSearchProcColumnObj->name);
+                        dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
                         return DAM_FAILURE;
                     }
                 }
@@ -1289,7 +1326,9 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                     }
                     else
                     {
-                        tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV,"HPCC_Conn:Output column descriptor not found/not supported '%s'\n",(pSearchProcColumnObj->name));
+                        StringBuffer err;
+                        err.setf("HPCC_Conn:OAIP_schema : Input column descriptor '%s' not found/not supported",pSearchProcColumnObj->name);
+                        dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
                         return DAM_FAILURE;
                     }
                 }

--- a/src/hpcc_util.cpp
+++ b/src/hpcc_util.cpp
@@ -75,6 +75,10 @@ int hpcc_add_row(HPCC_STMT_DA *pStmtDA, DAM_HROW hrow, IPropertyTree * pRow, CCo
         tm_trace(hpcc_tm_Handle, UL_TM_ERRORS, "HPCC_Conn:hpcc_add_row unknown data type %u\n", (pCol->m_iXOType));
     }
 
+    StringBuffer err;
+    err.setf("HPCC_Conn:hpcc_add_row : Unsupported pCol->m_iXOType type '%d'", pCol->m_iXOType);
+    dam_addError(pStmtDA->pConnDA->dam_hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
+
     return DAM_FAILURE;
 }
 
@@ -92,6 +96,7 @@ int             hpcc_exec(const char * sqlQuery, const char * targetQuerySet, HP
     int         iRetCode;
 
     //call ws_sql to get row(s)
+    sbErrors.set("HPCC_Conn:hpcc_exec : ");
     if (!pHPCCdb->executeSQL(sqlQuery, targetQuerySet, sbErrors))
     {
         dam_addError(pStmtDA->pConnDA->dam_hdbc, pStmtDA->dam_hstmt, DAM_IP_ERROR, 0, (char *)sbErrors.str());


### PR DESCRIPTION
The Progress SDK provides and API "dam_addError()" where you can report an
error string that will be displayed to the user whenever we return an error
from a Progress callback. HPCC-ODBC is enhanced here to utilize this api to
provide as much detailed information to the caller as possible

Signed-off-by: William Whitehead <william.whitehead@lexisnexis.com>