### PR TITLE
ODBC-13 Errors adding individual tables/columns should not be treated as...

### DIFF
--- a/src/hpcc_drv.cpp
+++ b/src/hpcc_drv.cpp
@@ -930,7 +930,7 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                     DAM_OBJ_LIST pList,
                     DAM_OBJ pSearchObj)
 {
-    tm_trace(hpcc_tm_Handle, UL_TM_F_TRACE, "HPCC_Conn:OAIP_schema() has been called \n", ());
+    tm_trace(hpcc_tm_Handle, UL_TM_F_TRACE, "HPCC_Conn:OAIP_schema() has been called\n", ());
 
     int rc;
     HPCC_CONN_DA *pConnDA = (HPCC_CONN_DA *)hdbc;
@@ -966,6 +966,9 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                             (char*)table.queryDescription()); //char   *      remarks
                         if (rc != DAM_SUCCESS)
                         {
+                            StringBuffer err;
+                            err.setf("HPCC_Conn:OAIP_schema : dam_add_damobj_table failed on '%s'",(char*)table.queryName());
+                            dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
                             return DAM_FAILURE;
                         }
                     }
@@ -999,7 +1002,9 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                             NULL);                     //char   *      remarks
                         if (rc != DAM_SUCCESS)
                         {
-                            return DAM_FAILURE;
+                            //Dont treat as failure, since others may succeed
+                            tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV, "HPCC_Conn:OAIP_schema : dam_add_damobj_table failed on '%s', ignoring\n",(table.queryName()));
+                            continue;
                         }
                     }
                 }
@@ -1036,7 +1041,7 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                                     pSearchObj,             //DAM_OBJ      pSearchObj,
                                     HPCC_QUALIFIER_NAME,    //char   *     table_qualifier,
                                     (char*)table.queryOwner(),//char   *     table_owner,
-                                    (char*)table.queryName(),//char  *   table_name
+                                    (char*)table.queryName(),//char  *      table_name
                                     (char*)col->m_name.get(),//char   *     column_name,
                                     col->m_iXOType,         //short        data_type,
                                     (char*)col->m_type_name.get(),//char *  type_name,
@@ -1053,9 +1058,10 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                                     NULL);                  //char   *     remarks
                             if (rc != DAM_SUCCESS)
                             {
-                                return DAM_FAILURE;
+                                //Dont treat as failure, since others may succeed
+                                tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV, "HPCC_Conn:OAIP_schema : dam_add_damobj_column failed on table '%s', column '%s', type '%s', ignoring\n",(table.queryName(),col->m_name.get(),col->m_type_name.get() ));
+                                continue;
                             }
-
                         }
                     }
                 }
@@ -1106,7 +1112,9 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                                     NULL);                  //char   *     remarks
                                 if (rc != DAM_SUCCESS)
                                 {
-                                    return DAM_FAILURE;
+                                    //Dont treat as failure, since others may succeed
+                                    tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV, "HPCC_Conn:OAIP_schema : dam_add_damobj_column failed on table '%s', column '%s', type '%s', ignoring\n",(table.queryName(),col->m_name.get(),col->m_type_name.get() ));
+                                    continue;
                                 }
                             }
                         }
@@ -1186,7 +1194,9 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                             NULL);                  // char   *remarks
                         if (rc != DAM_SUCCESS)
                         {
-                            return DAM_FAILURE;
+                            //Dont treat as failure, since others may succeed
+                            tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV, "HPCC_Conn:OAIP_schema : dam_add_damobj_proc failed on procedure '%s', ignoring\n",( procName.str() ));
+                            continue;
                         }
                     }
                 }
@@ -1237,7 +1247,9 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                                     NULL);                      //   char   *remarks
                         if (rc != DAM_SUCCESS)
                         {
-                            return DAM_FAILURE;
+                            //Dont treat as failure, since others may succeed
+                            tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV, "HPCC_Conn:OAIP_schema : dam_add_damobj_proc_column failed on procedure '%s', column '%s', ignoring\n",(pSearchProcColumnObj->name,pCol->m_name.get()  ));
+                            continue;
                         }
                     }
                     else
@@ -1282,7 +1294,9 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                                             NULL);                      //   char   *remarks
                                 if (rc != DAM_SUCCESS)
                                 {
-                                    return DAM_FAILURE;
+                                    //Dont treat as failure, since others may succeed
+                                    tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV, "HPCC_Conn:OAIP_schema : dam_add_damobj_proc_column failed on procedure '%s', column '%s', ignoring\n",(pSearchProcColumnObj->name,pCol->m_name.get()  ));
+                                    continue;
                                 }
                             }
                         }
@@ -1298,6 +1312,7 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
         }
 
     default:
+        tm_trace(hpcc_tm_Handle,UL_TM_MINOR_EV, "HPCC_Conn:OAIP_schema : Ignoring unsupported schema type '%d'\n",( iType ));
         break;
     }
 

--- a/src/hpcc_drv.cpp
+++ b/src/hpcc_drv.cpp
@@ -1004,7 +1004,6 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                         {
                             //Dont treat as failure, since others may succeed
                             tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV, "HPCC_Conn:OAIP_schema : dam_add_damobj_table failed on '%s', ignoring\n",(table.queryName()));
-                            continue;
                         }
                     }
                 }
@@ -1060,7 +1059,6 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                             {
                                 //Dont treat as failure, since others may succeed
                                 tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV, "HPCC_Conn:OAIP_schema : dam_add_damobj_column failed on table '%s', column '%s', type '%s', ignoring\n",(table.queryName(),col->m_name.get(),col->m_type_name.get() ));
-                                continue;
                             }
                         }
                     }
@@ -1114,7 +1112,6 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                                 {
                                     //Dont treat as failure, since others may succeed
                                     tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV, "HPCC_Conn:OAIP_schema : dam_add_damobj_column failed on table '%s', column '%s', type '%s', ignoring\n",(table.queryName(),col->m_name.get(),col->m_type_name.get() ));
-                                    continue;
                                 }
                             }
                         }
@@ -1196,7 +1193,6 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                         {
                             //Dont treat as failure, since others may succeed
                             tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV, "HPCC_Conn:OAIP_schema : dam_add_damobj_proc failed on procedure '%s', ignoring\n",( procName.str() ));
-                            continue;
                         }
                     }
                 }
@@ -1249,7 +1245,6 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                         {
                             //Dont treat as failure, since others may succeed
                             tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV, "HPCC_Conn:OAIP_schema : dam_add_damobj_proc_column failed on procedure '%s', column '%s', ignoring\n",(pSearchProcColumnObj->name,pCol->m_name.get()  ));
-                            continue;
                         }
                     }
                     else
@@ -1296,7 +1291,6 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                                 {
                                     //Dont treat as failure, since others may succeed
                                     tm_trace(hpcc_tm_Handle,UL_TM_MAJOR_EV, "HPCC_Conn:OAIP_schema : dam_add_damobj_proc_column failed on procedure '%s', column '%s', ignoring\n",(pSearchProcColumnObj->name,pCol->m_name.get()  ));
-                                    continue;
                                 }
                             }
                         }


### PR DESCRIPTION
... fatal

Currently if there is any error when populating Progress with lists of tables
and/or columns, the entire operation is aborted. Instead we should log an
error with that particular table/column and allow the remaining ones

Signed-off-by: William Whitehead <william.whitehead@lexisnexis.com>