### PR TITLE
ODBC-17 Minor changes needed for 32/64 builds

### DIFF
--- a/hpcc_odbc.vcproj
+++ b/hpcc_odbc.vcproj
@@ -184,10 +184,10 @@
 				AdditionalLibraryDirectories="..\HPCC-Lib64\;C:\Program Files\Progress\DataDirect\oaodbclocal72\ip\lib"
 				ManifestFile="./Release_x64\$(TargetFileName).intermediate.manifest"
 				ModuleDefinitionFile=".\src\hpccodbc.def"
-				ProgramDatabaseFile=".\Release_x64/hpcc_odbc_32.pdb"
+				ProgramDatabaseFile=".\Release_x64/hpcc_odbc_64.pdb"
 				RandomizedBaseAddress="1"
 				DataExecutionPrevention="0"
-				ImportLibrary=".\Release_x64/hpcc_odbc_32.lib"
+				ImportLibrary=".\Release_x64/hpcc_odbc_64.lib"
 				TargetMachine="17"
 			/>
 			<Tool
@@ -389,10 +389,10 @@
 				ManifestFile=".\Debug_x64/$(TargetFileName).intermediate.manifest"
 				ModuleDefinitionFile=".\src\hpccodbc.def"
 				GenerateDebugInformation="true"
-				ProgramDatabaseFile=".\Debug_x64/hpcc_odbc_32.pdb"
+				ProgramDatabaseFile=".\Debug_x64/hpcc_odbc_64.pdb"
 				RandomizedBaseAddress="1"
 				DataExecutionPrevention="0"
-				ImportLibrary=".\Debug_x64/hpcc_odbc_32.lib"
+				ImportLibrary=".\Debug_x64/hpcc_odbc_64.lib"
 				TargetMachine="17"
 				CLRThreadAttribute="0"
 			/>

--- a/package_hpcc_odbc64.bat
+++ b/package_hpcc_odbc64.bat
@@ -1,6 +1,6 @@
 if "%PROGRESS_SDK64_DIR%".=="". set PROGRESS_SDK64_DIR=C:\Program Files\Progress\DataDirect\oaodbclocal72
 if "%HPCCODBC_SRC_DIR%".=="". set HPCCODBC_SRC_DIR=C:\hpcc\HPCC-ODBC
-if "%HPCC_BUILD_DIR_64%".=="". set HPCC_BUILD_DIR_64=C:\hpcc\HPCC-Lib
+if "%HPCC_BUILD_DIR_64%".=="". set HPCC_BUILD_DIR_64=C:\hpcc\HPCC-Lib64
 
 @echo on
 @echo ===============================================================================

--- a/progress/32bit/custom.ini
+++ b/progress/32bit/custom.ini
@@ -29,7 +29,7 @@ ProductUpdateURL=http://hpccsystems.com/download
 ;Specific Installation information
 ;----------------------------------------------------------
 FolderName=HPCC Systems\HPCC-ODBC32 Connector
-AppBasePath=${Program Files}\HPCCSystems\HPCC-ODBC Connector
+AppBasePath=${Program Files}\HPCCSystems\HPCC-ODBC32 Connector
 ;UnInstallLocation=
 
 ;----------------------------------------------------------

--- a/progress/64bit/custom.ini
+++ b/progress/64bit/custom.ini
@@ -29,7 +29,7 @@ ProductUpdateURL=http://hpccsystems.com/download
 ;Specific Installation information
 ;----------------------------------------------------------
 FolderName=HPCC Systems\HPCC-ODBC64 Connector
-AppBasePath=${Program Files}\HPCCSystems\HPCC-ODBC Connector
+AppBasePath=${Program Files}\HPCCSystems\HPCC-ODBC64 Connector
 ;UnInstallLocation=
 
 ;----------------------------------------------------------


### PR DESCRIPTION
There are a few changes needed to the build process to ensure the 32
and 64 bit builds don't collide with each other. Specifically the drivers
will install in folders with the architecture (32/64) as part of the path
name

Signed-off-by: William Whitehead <william.whitehead@lexisnexis.com>