### PR TITLE
ODBC-19 Refactor table/procedure cache to persist between sessions

### DIFF
--- a/progress/32bit/cla.inp
+++ b/progress/32bit/cla.inp
@@ -16,7 +16,7 @@ dsaa ${ServiceName_C} HPCC-ODBC32_ConnDS DataSourceIPProperties HPCC-ODBC32_Conn
 
 saa ${ServiceName_C}  ServiceEnvironmentVariable "PATH=${InstallDir}\ip\bin"
 
-dsaa ${ServiceName_C} HPCC-ODBC32_ConnDS DataSourceIPCustomProperties PROTOCOL=http;WSSQLPORT=8510;WSSQLIP=127.0.0.1;CLUSTER=hthor;DEFAULTQUERYSET=thor;MAXROWBUFFCOUNT=10000;
+dsaa ${ServiceName_C} HPCC-ODBC32_ConnDS DataSourceIPCustomProperties PROTOCOL=http;WSSQLPORT=8510;WSSQLIP=127.0.0.1;CLUSTER=hthor;DEFAULTQUERYSET=thor;MAXROWBUFFCOUNT=10000;CACHETIMEOUT=30;
 
 e "SaveConfig" 
 SaveConfig

--- a/progress/32bit/readme.txt
+++ b/progress/32bit/readme.txt
@@ -30,7 +30,7 @@ Once the plug-in is installed, you must set the IP address of the HPCC WsSQL ser
 	1) In the MMC console, expand the "Console Root" > "Manager" >  "C:\Program Files (x86)\HPCCSystems\HPCC-ODBC Connector\cfg\oadm.ini" > "Services" > "HPCC-ODBC_ConnSvc" > "Data Source Settings" > "HPCC-ODBC_ConnDS"
 	2) Select "IP Parameters"
 	3) Double-click the "DataSourceIPCustomProperties" and edit any of the values in the key/value pairs listed to settings that you prefer. 
-	     The default settings are : PROTOCOL=http;WSSQLPORT=8510;WSSQLIP=127.0.0.1;CLUSTER=hthor;DEFAULTQUERYSET=thor;MAXROWBUFFCOUNT=10000;
+           The default settings are : PROTOCOL=http;WSSQLPORT=8510;WSSQLIP=127.0.0.1;CLUSTER=hthor;DEFAULTQUERYSET=thor;MAXROWBUFFCOUNT=10000;CACHETIMEOUT=30;
 	4) You must change the WSSQLIP value to the IP address of the HPCC ESP Server to which the WsSQL service is bound.
 	5) Ensure the WSSQLPORT is correct. Check with your HPCC system admin.
 	6) Select OK, the "File > "Save" and agree to all the prompts

--- a/progress/64bit/cla.inp
+++ b/progress/64bit/cla.inp
@@ -16,7 +16,7 @@ dsaa ${ServiceName_C} HPCC-ODBC64_ConnDS DataSourceIPProperties HPCC-ODBC64_Conn
 
 saa ${ServiceName_C}  ServiceEnvironmentVariable "PATH=${InstallDir}\ip\bin"
 
-dsaa ${ServiceName_C} HPCC-ODBC64_ConnDS DataSourceIPCustomProperties PROTOCOL=http;WSSQLPORT=8510;WSSQLIP=127.0.0.1;CLUSTER=hthor;DEFAULTQUERYSET=thor;MAXROWBUFFCOUNT=10000;
+dsaa ${ServiceName_C} HPCC-ODBC64_ConnDS DataSourceIPCustomProperties PROTOCOL=http;WSSQLPORT=8510;WSSQLIP=127.0.0.1;CLUSTER=hthor;DEFAULTQUERYSET=thor;MAXROWBUFFCOUNT=10000;CACHETIMEOUT=30;
 
 e "SaveConfig" 
 SaveConfig

--- a/progress/64bit/readme.txt
+++ b/progress/64bit/readme.txt
@@ -30,7 +30,7 @@ Once the plug-in is installed, you must set the IP address of the HPCC WsSQL ser
 	1) In the MMC console, expand the "Console Root" > "Manager" >  "C:\Program Files\HPCCSystems\HPCC-ODBC Connector\cfg\oadm.ini" > "Services" > "HPCC-ODBC_ConnSvc" > "Data Source Settings" > "HPCC-ODBC_ConnDS"
 	2) Select "IP Parameters"
 	3) Double-click the "DataSourceIPCustomProperties" and edit any of the values in the key/value pairs listed to settings that you prefer. 
-	     The default settings are : PROTOCOL=http;WSSQLPORT=8510;WSSQLIP=127.0.0.1;CLUSTER=hthor;DEFAULTQUERYSET=thor;MAXROWBUFFCOUNT=10000;
+           The default settings are : PROTOCOL=http;WSSQLPORT=8510;WSSQLIP=127.0.0.1;CLUSTER=hthor;DEFAULTQUERYSET=thor;MAXROWBUFFCOUNT=10000;CACHETIMEOUT=30;
 	4) You must change the WSSQLIP value to the IP address of the HPCC ESP Server to which the WsSQL service is bound.
 	5) Ensure the WSSQLPORT is correct. Check with your HPCC system admin.
 	6) Select OK, the "File > "Save" and agree to all the prompts

--- a/src/hpcc_drv.cpp
+++ b/src/hpcc_drv.cpp
@@ -105,7 +105,7 @@ const char * pszWSSQLIP         = "WSSQLIP=";
 const char * pszCLUSTER         = "CLUSTER=";
 const char * pszDEFAULTQUERYSET = "DEFAULTQUERYSET=";
 const char * pszMAXROWBUFFCOUNT = "MAXROWBUFFCOUNT=";
-
+const char * pszCACHETIMEOUT    = "CACHETIMEOUT=";
 
 /************************************************************************
 Function:       OAIP_init()
@@ -360,13 +360,15 @@ int             OAIP_connect(DAM_HDBC dam_hdbc, IP_HENV henv,
         defaultQuerySet.set("roxie");
 
     //Isolate Default QuerySet
-    aindex_t maxFetchRowCount;
     p = sl_strstr(sIPCustomProperties, pszMAXROWBUFFCOUNT);
-    if (p)
-        maxFetchRowCount = p ? atol(p + strlen(pszMAXROWBUFFCOUNT)) : -1;//-1 if no limit
+    aindex_t maxFetchRowCount = p ? atol(p + strlen(pszMAXROWBUFFCOUNT)) : -1;//-1 if no limit
+
+    //Isolate Cache Timeout
+    p = sl_strstr(sIPCustomProperties, pszCACHETIMEOUT);
+    aindex_t cacheTimeout = p ? atol(p + strlen(pszCACHETIMEOUT)) : 30;//30 minutes if not specified
 
     /* initialize the IP data source */
-    pConnDA->pHPCCdb = new HPCCdb(hpcc_tm_Handle, protocol.str(), wssqlPort.str(), sUserName, sPassword, wssqlIP.str(), targetCluster.str(), defaultQuerySet.str(), maxFetchRowCount);
+    pConnDA->pHPCCdb = new HPCCdb(hpcc_tm_Handle, protocol.str(), wssqlPort.str(), sUserName, sPassword, wssqlIP.str(), targetCluster.str(), defaultQuerySet.str(), maxFetchRowCount, cacheTimeout);
     if (!pConnDA->pHPCCdb->getHPCCDBSystemInfo())
     {
         delete pConnDA->pHPCCdb;

--- a/src/hpccdb.hpp
+++ b/src/hpccdb.hpp
@@ -180,9 +180,9 @@ private:
     StringAttr                  m_defaultQuerySet;//thor, roxie, thor_roxie, etc
     StringAttr                  m_FullHPCCVersion;
     aindex_t                    m_maxFetchRowCount;//max num rows to fetch in a single retrieval
+    aindex_t                    m_cacheTimeout;//in minutes
 
     Owned<IClientwssql>         m_clientWs_sql;//ws_sql client
-    MapStringToMyClass<CTable>  m_tableSchemaCache;
 
     vector<CColumn*>            m_hpccColPtrs;  //Ordered array of pointers to output CColumns that reside in m_schemaCache
 
@@ -203,7 +203,7 @@ private:
     bool        checkForErrors(const IMultiException & _exc, IConstECLWorkunit & _wu, StringBuffer & _sbErrors);
 
 public:
-    HPCCdb(TM_ModuleCB tmHandle, const char * _protocol, const char * _wsSqlPort, const char * _user, const char * _pwd, const char * _wssqlIP, const char * _targetCluster, const char * _defaultQuerySet, aindex_t _maxFetchRowCount);
+    HPCCdb(TM_ModuleCB tmHandle, const char * _protocol, const char * _wsSqlPort, const char * _user, const char * _pwd, const char * _wssqlIP, const char * _targetCluster, const char * _defaultQuerySet, aindex_t _maxFetchRowCount, aindex_t _cacheTimeout);
     virtual ~HPCCdb();
 
     const char * queryUserName()                            { return m_userName; }
@@ -216,6 +216,7 @@ public:
     const char *queryTargetCluster()                        { return m_targetCluster; }
     const char *queryDefaultQuerySet()                      { return m_defaultQuerySet; }
     aindex_t    queryMaxFetchRowCount()                     { return m_maxFetchRowCount; }
+    aindex_t    queryCacheTimeout()                         { return m_cacheTimeout; }
 
     const char *queryCurrentQuerySet()                      { return m_currentQuerySet.get(); }
     void        setCurrentQuerySet(const char * qs)         { m_currentQuerySet.set(qs); }


### PR DESCRIPTION
Currently the cache of table/column metadata is kept in a session specific
cache. It was found through testing (Microsoft Excel/Access) that every
ODBC request is initiated through a new session, making the cache of little
value. This PR reimplements the cache as a singleton that persists between
sessions

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>