### PR TITLE
ODBC-22 Improve cache to reduce calls to HPCC

### DIFF
--- a/src/hpcc_drv.cpp
+++ b/src/hpcc_drv.cpp
@@ -1006,10 +1006,11 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                 {
                     //I don't think there will ever be more than one table matching
                     //the given table_name, but looping on it just in case
-                    ForEachItemIn(i, _tables)
+                    ForEachItemIn(idxTbl, _tables)
                     {
-                        CTable &table = _tables.item(i);
-                        if (hpcc_is_matching_table(pSearchTableObj, HPCC_QUALIFIER_NAME, HPCC_CATALOG_NAME, (char*)table.queryName()))
+                        CTable &table = _tables.item(idxTbl);
+                        char * tableName = (char*)table.queryName();
+                        if (hpcc_is_matching_table(pSearchTableObj, HPCC_QUALIFIER_NAME, HPCC_CATALOG_NAME, tableName))
                         {
                             rc = dam_add_damobj_table(
                                 pMemTree,                   //XM_Tree *     pMemTree,
@@ -1017,7 +1018,7 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                                 pSearchObj,                 //DAM_OBJ       pSearchObj,
                                 HPCC_QUALIFIER_NAME,        //char   *      table_qualifier,
                                 HPCC_CATALOG_NAME,          //char   *      table_owner,
-                                (char*)table.queryName(),   //char   *      table_name,
+                                tableName,                  //char   *      table_name,
                                 "TABLE",                    //char   *      table_type, (TABLE == managed by IP)
                                 NULL,                       //char   *      table_path,
                                 NULL,                       //char   *      table_userdata
@@ -1409,7 +1410,7 @@ static int      hpcc_is_matching_table(damobj_table *pSearchObj,
         if (DAMOBJ_IS_SET(pSearchObj->table_name_len) && sl_stricmp(pSearchObj->table_name, table_name))
             return FALSE;
     }
-   else
+    else
     {
         /* match the search pattern */
         if (DAMOBJ_IS_SET(pSearchObj->table_qualifier_len) && dam_strlikecmp(pSearchObj->table_qualifier, table_qualifier))

--- a/src/hpcc_drv.cpp
+++ b/src/hpcc_drv.cpp
@@ -193,13 +193,13 @@ int             OAIP_getInfo(IP_HENV ip_henv, IP_HDBC ip_hdbc, IP_HSTMT hstmt, i
         break;
 
     case IP_INFO_SUPPORT_SCHEMA_SEARCH_PATTERN:
-        tm_trace(hpcc_tm_Handle, UL_TM_MAJOR_EV, "HPCC_Conn(): IP_INFO_SUPPORT_SCHEMA_SEARCH_PATTERN=%d\n", (sFunctionName, bAllowSchemaSearchPattern));
+        tm_trace(hpcc_tm_Handle, UL_TM_MAJOR_EV, "HPCC_Conn: IP_INFO_SUPPORT_SCHEMA_SEARCH_PATTERN=%d\n", (sFunctionName, bAllowSchemaSearchPattern));
         *pShortIntValue = (short)bAllowSchemaSearchPattern;
         break;
 
     default:
         /* we will not report it as error, since the ip_getInfo() is an optional implementation */
-        tm_trace(hpcc_tm_Handle, UL_TM_TRIVIA, "HPCC_Conn(): Information type:%d is out of range\n", (sFunctionName, iInfoType));
+        tm_trace(hpcc_tm_Handle, UL_TM_TRIVIA, "HPCC_Conn: Information type:%d is out of range\n", (sFunctionName, iInfoType));
         return DAM_NOT_AVAILABLE;
         break;
     }
@@ -1004,27 +1004,32 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                 IArrayOf<CTable> _tables;
                 if (pConnDA->pHPCCdb->getTableSchema(pSearchTableObj->table_name, _tables))
                 {
-                    CTable &table = _tables.item(0);
-                    if (hpcc_is_matching_table(pSearchTableObj, HPCC_QUALIFIER_NAME, HPCC_CATALOG_NAME, (char*)table.queryName()))
+                    //I don't think there will ever be more than one table matching
+                    //the given table_name, but looping on it just in case
+                    ForEachItemIn(i, _tables)
                     {
-                        rc = dam_add_damobj_table(
-                            pMemTree,                   //XM_Tree *     pMemTree,
-                            pList,                      //DAM_OBJ_LIST  pList,
-                            pSearchObj,                 //DAM_OBJ       pSearchObj,
-                            HPCC_QUALIFIER_NAME,        //char   *      table_qualifier,
-                            HPCC_CATALOG_NAME,          //char   *      table_owner,
-                            (char*)table.queryName(),   //char   *      table_name,
-                            "TABLE",                    //char   *      table_type, (TABLE == managed by IP)
-                            NULL,                       //char   *      table_path,
-                            NULL,                       //char   *      table_userdata
-                            NULL,                       //char   *      function_support, IP_TABLE_SUPPORT_SELECT
-                            (char*)table.queryDescription()); //char   *      remarks
-                        if (rc != DAM_SUCCESS)
+                        CTable &table = _tables.item(i);
+                        if (hpcc_is_matching_table(pSearchTableObj, HPCC_QUALIFIER_NAME, HPCC_CATALOG_NAME, (char*)table.queryName()))
                         {
-                            StringBuffer err;
-                            err.setf("HPCC_Conn:OAIP_schema : dam_add_damobj_table failed on '%s'",(char*)table.queryName());
-                            dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
-                            return DAM_FAILURE;
+                            rc = dam_add_damobj_table(
+                                pMemTree,                   //XM_Tree *     pMemTree,
+                                pList,                      //DAM_OBJ_LIST  pList,
+                                pSearchObj,                 //DAM_OBJ       pSearchObj,
+                                HPCC_QUALIFIER_NAME,        //char   *      table_qualifier,
+                                HPCC_CATALOG_NAME,          //char   *      table_owner,
+                                (char*)table.queryName(),   //char   *      table_name,
+                                "TABLE",                    //char   *      table_type, (TABLE == managed by IP)
+                                NULL,                       //char   *      table_path,
+                                NULL,                       //char   *      table_userdata
+                                NULL,                       //char   *      function_support, IP_TABLE_SUPPORT_SELECT
+                                (char*)table.queryDescription()); //char   *      remarks
+                            if (rc != DAM_SUCCESS)
+                            {
+                                StringBuffer err;
+                                err.setf("HPCC_Conn:OAIP_schema : dam_add_damobj_table failed on '%s'",(char*)table.queryName());
+                                dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
+                                return DAM_FAILURE;
+                            }
                         }
                     }
                 }
@@ -1404,7 +1409,7 @@ static int      hpcc_is_matching_table(damobj_table *pSearchObj,
         if (DAMOBJ_IS_SET(pSearchObj->table_name_len) && sl_stricmp(pSearchObj->table_name, table_name))
             return FALSE;
     }
-    else
+   else
     {
         /* match the search pattern */
         if (DAMOBJ_IS_SET(pSearchObj->table_qualifier_len) && dam_strlikecmp(pSearchObj->table_qualifier, table_qualifier))

--- a/src/hpccdb.cpp
+++ b/src/hpccdb.cpp
@@ -47,13 +47,48 @@ public:
         m_metaDataCacheComplete = false;
     }
 
-    CTable * getValue(const char * tblName)
+    aindex_t getMatchingTables(const char * tblFilter, IArrayOf<CTable> &_tables, bool bExact)
     {
         CriticalBlock b(m_crit);
-        return m_tableCache.getValue(tblName);
+        HashIterator iter(m_tableCache);
+        if (bExact)
+        {
+            ForEach(iter)
+            {
+                CTable *tbl = m_tableCache.mapToValue(&iter.query());
+                if (0 == strcmp(tblFilter, tbl->queryName()))
+                {
+                    _tables.append(*(LINK(tbl)));
+                    break;
+                }
+            }
+        }
+        else
+        {
+            unsigned filterLen = strlen(tblFilter);
+            ForEach(iter)
+            {
+                CTable *tbl = m_tableCache.mapToValue(&iter.query());
+                if (0 == strncmp(tblFilter, tbl->queryName(), filterLen))
+                    _tables.append(*(LINK(tbl)));
+            }
+        }
+        return _tables.ordinality();
     }
 
-    void setValue(const char * tblName, Owned<CTable> *tblEntry)
+    aindex_t getAllCachedTables(IArrayOf<CTable> &_tables)
+    {
+        CriticalBlock b(m_crit);
+        HashIterator iter(m_tableCache);
+        ForEach(iter)
+        {
+            CTable *tbl = m_tableCache.mapToValue(&iter.query());
+            _tables.append(*(LINK(tbl)));
+        }
+        return _tables.ordinality();
+    }
+
+    void addTable(const char * tblName, Owned<CTable> *tblEntry)
     {
         CriticalBlock b(m_crit);
         m_tableCache.setValue(tblName, *tblEntry);
@@ -333,8 +368,8 @@ bool HPCCdb::getTableSchema(const char * _tableFilter, IArrayOf<CTable> &_tables
 {
     tm_trace(driver_tm_Hdle, UL_TM_INFO, "HPCC_Conn:call to HPCCdb::getTableSchema('%s')\n", (_tableFilter));
 
+    //Cache management
     CTableSchemaCache * pCache = CTableSchemaCache::queryInstance();
-
     static time_t m_lastCacheClear = 0;
     if ((msTick() - m_lastCacheClear) >= (queryCacheTimeout() * 60 * 1000))
     {
@@ -342,14 +377,28 @@ bool HPCCdb::getTableSchema(const char * _tableFilter, IArrayOf<CTable> &_tables
         m_lastCacheClear = msTick();
     }
 
+    if (_tableFilter && !*_tableFilter)
+        _tableFilter = NULL;
+
+    //Allow backend to handle wildcards
+    bool bIsWildcard;
+    if (_tableFilter && strchr(_tableFilter, '*'))
+    {
+        //I dont think this code is reachable because I have never seen a wildcard passed in. Instead the client
+        //calls us to get everything and they filter out nonmatches. However, just in case, here it is...
+        bIsWildcard = true;
+        pCache->clearCache();
+        m_lastCacheClear = msTick();
+    }
+    else
+        bIsWildcard = false;
+
     //First look in the schemaCache
     if (_tableFilter)
     {
-        CTable * cachedEntry = pCache->getValue(_tableFilter);
-        if (cachedEntry)
+        if (pCache->getMatchingTables(_tableFilter, _tables, true))
         {
             tm_trace(driver_tm_Hdle, UL_TM_INFO, "HPCC_Conn:using cached table schema info\n", ());
-            _tables.append(*(LINK(cachedEntry)));
             return true;
         }
         else if (pCache->queryMetaDataCacheComplete())//we have everything, and it's not here
@@ -421,7 +470,7 @@ bool HPCCdb::getTableSchema(const char * _tableFilter, IArrayOf<CTable> &_tables
             {
                 CHPCCColumn &columnItem = (CHPCCColumn &)columns.item(columnsIdx);
                 Owned<CColumn> columnEntry;
-                tm_trace(driver_tm_Hdle, UL_TM_F_TRACE, "   HPCC:Found column '%s'(%s)\n", (columnItem.getName(),columnItem.getType()));
+                tm_trace(driver_tm_Hdle, UL_TM_F_TRACE, "   HPCC_Conn:Found column '%s'(%s)\n", (columnItem.getName(),columnItem.getType()));
                 columnEntry.setown(new CColumn(columnItem.getName()));
 #ifdef _WIN32
                 StringBuffer sb;
@@ -433,26 +482,20 @@ bool HPCCdb::getTableSchema(const char * _tableFilter, IArrayOf<CTable> &_tables
                 //Add to column array
                 tblEntry->addColumn(LINK(columnEntry));
             }
-            pCache->setValue(tableItem.getName(), &tblEntry);//save in the schemaCache
-            if (_tableFilter == NULL)
-            {
-                _tables.append(*(LINK(tblEntry)));
-            }
+            pCache->addTable(tableItem.getName(), &tblEntry);//save in the schemaCache
         }
     }
 
-    if (_tableFilter)
+    if (_tableFilter && !bIsWildcard)
     {
-        CTable * cachedEntry = pCache->getValue(_tableFilter);
-        if (cachedEntry)
-        {
-            _tables.append(*(LINK(cachedEntry)));
+        if (pCache->getMatchingTables(_tableFilter, _tables, true))
             return true;
-        }
+        else
+            tm_trace(driver_tm_Hdle, UL_TM_ERRORS, "HPCC_Conn:Could not find table matching '%s'\n", (_tableFilter));
     }
     else
     {
-        if (!_tables.empty())
+        if (pCache->getAllCachedTables(_tables))
             return true;
         else
             tm_trace(driver_tm_Hdle, UL_TM_ERRORS, "HPCC_Conn:Could not find any tables\n", ());
@@ -527,7 +570,6 @@ bool HPCCdb::executeSQL(const char * sql, const char * targetQuerySet, StringBuf
     req.setown( createClientExecuteSQLRequest());
     req->setSqlText(sql);
     req->setSuppressXmlSchema(true);
-
     req->setResultWindowStart(0);
     if (m_maxFetchRowCount != -1)
         req->setResultWindowCount(m_maxFetchRowCount);

--- a/src/hpccdb.cpp
+++ b/src/hpccdb.cpp
@@ -376,22 +376,21 @@ bool HPCCdb::getTableSchema(const char * _tableFilter, IArrayOf<CTable> &_tables
         sbTableFilter.set(_tableFilter);
 
     //Allow backend to handle wildcards
-    bool bIsWildcard;
-    if (_tableFilter && (strchr(_tableFilter, '*') || strchr(_tableFilter, '%')))
+    bool bIsWildcard = false;
+    for (char * p = (char *)sbTableFilter.str(); *p; p++)
     {
-        //I dont think this code is reachable because I have never seen a wildcard passed in. Instead the client
-        //calls us to get everything and they filter out nonmatches. However, just in case, here it is...
-        bIsWildcard = true;
-        pCache->clearCache();
-        m_lastCacheClear = msTick();
-        for (char * p = (char *)sbTableFilter.str(); *p; p++)
+        if (*p == '*' || *p == '%')
         {
+            if (!bIsWildcard)
+            {
+                bIsWildcard = true;
+                pCache->clearCache();
+                m_lastCacheClear = msTick();
+            }
             if (*p == '%')
                 *p = '*';//wssql only recognizes * as wildcard
         }
     }
-    else
-        bIsWildcard = false;
 
     //First look in the schemaCache
     if (_tableFilter)


### PR DESCRIPTION
While testing with Tableau, it was found that the metadata cache could be
improved to better handle wildcard searches and exhaustive searches. This
PR refactors the cache and cache manager to better handle these cases, and
also adds a multi-table loop to the table schema query handler in case there
is more than one match

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>