### PR TITLE
ODBC-25 Exception when NULL provided as procedure name

### DIFF
--- a/src/hpccdb.hpp
+++ b/src/hpccdb.hpp
@@ -227,19 +227,22 @@ public:
     //An SQL stored procedure is loosly the same as an HPCC deployed query
     CMyQuerySetQuery * queryStoredProcedure(const char * querySetName, const char * name)
     {
-        if (!m_bGotDeployedQueries)
-            getDeployedQueries();//populate cache
-
-        ForEachItemIn(Idx, m_arrQuerySets)//thor,hthor,roxie
+        if ( querySetName && *querySetName && name && *name)
         {
-            CMyQuerySet &qrySet = (CMyQuerySet&)m_arrQuerySets.item(Idx);
-            if (0 == strcmp(qrySet.queryName(), querySetName))
+            if (!m_bGotDeployedQueries)
+                getDeployedQueries();//populate cache
+
+            ForEachItemIn(Idx, m_arrQuerySets)//thor,hthor,roxie
             {
-                CMyQuerySetQuery * pQuery = (CMyQuerySetQuery*)qrySet.queryQuery(name);
-                if (pQuery)
-                    return pQuery;
-                else
-                    break;
+                CMyQuerySet &qrySet = (CMyQuerySet&)m_arrQuerySets.item(Idx);
+                if (0 == strcmp(qrySet.queryName(), querySetName))
+                {
+                    CMyQuerySetQuery * pQuery = (CMyQuerySetQuery*)qrySet.queryQuery(name);
+                    if (pQuery)
+                        return pQuery;
+                    else
+                        break;
+                }
             }
         }
         return NULL;


### PR DESCRIPTION
When Progress calls OAIP_schema() DAMOBJ_TYPE_PROC_COLUMN and passes
NULL as the proc name, the code cores dereferencing that element. This
pull req checks for NULL and returns NULL on that condition

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>