### PR TITLE
ODBC-26 Improve enumeration of stored proc columns

### DIFF
--- a/src/hpcc_drv.cpp
+++ b/src/hpcc_drv.cpp
@@ -1296,7 +1296,7 @@ int     OAIP_schema(DAM_HDBC dam_hdbc,
                 if (!pQuery)
                 {
                     StringBuffer err;
-                    err.setf("HPCC_Conn:OAIP_schema : Query '%s.%s' not found",sbQS.str(), sbQN.str());
+                    err.setf("HPCC_Conn:OAIP_schema : Query '%s'.'%s' not found",sbQS.str(), sbQN.str());
                     dam_addError(dam_hdbc, NULL, DAM_IP_ERROR, 0, (char*)err.str());
                     return DAM_FAILURE;
                 }


### PR DESCRIPTION
Some ODBC clients cause the Progress SDK to pass NULLs in the stored proc
and table name field. Need to handle those, and stored procedure
queryset.name formatted stored proc names as well. This PR corrects these
limitations

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>