### PR TITLE
ODBC-28 Incorrect field lengths specified for BIGINT datatypes

### DIFF
--- a/src/hpcc_drv.cpp
+++ b/src/hpcc_drv.cpp
@@ -726,10 +726,10 @@ void populateOAtypes(CColumn * pColumn)
         int idx = 0;
         while (*(p + idx) && !isdigit((int)*(p + idx)))//search for optional precision
             idx++;
-        pColumn->m_char_max_length = 8;//num bytes
+        unsigned long maxLen = sizeof(__int64);//default num bytes
         if (*(p + idx) && isdigit((int)*(p + idx)))
-            pColumn->m_char_max_length = atoi(p + idx);
-        switch (pColumn->m_char_max_length)
+            maxLen = atoi(p + idx);
+        switch (maxLen)
         {
         case 1:
 /*
@@ -759,6 +759,7 @@ void populateOAtypes(CColumn * pColumn)
             pColumn->m_type_name.set("BIGINT");
             pColumn->m_iXOType = XO_TYPE_BIGINT;
             pColumn->m_numeric_precision = 19;
+            pColumn->m_char_max_length = sizeof(__int64);
             break;
         }
     }


### PR DESCRIPTION
ECL allows you to specify the number of bytes in an integer. So for instance
the ODBC Connector was mapping an ECL INTEGER5 to a 5 digit ODBC BIGINT.
Tableau did not like this, so I round anything over 4 bytes to 8 bytes

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>