### PR TITLE
ODBC-32 Create output columns using HPCC Metadata

### DIFF
--- a/src/hpcc_util.cpp
+++ b/src/hpcc_util.cpp
@@ -29,7 +29,9 @@ int hpcc_add_row(HPCC_STMT_DA *pStmtDA, DAM_HROW hrow, IPropertyTree * pRow, CCo
     int64           i64Val;
     double          dVal;
 
-    const char * value = pRow->queryProp(pCol->m_name);//string representation of the row data
+    const char * value = pRow->queryProp(pCol->m_alias);//Alias takes precedence over name
+    if (NULL == value)
+        value = pRow->queryProp(pCol->m_name);
     if (NULL == value)
     {
         //No value provided. Inject empty string or "XO_NULL_DATA"
@@ -97,7 +99,7 @@ int             hpcc_exec(const char * sqlQuery, const char * targetQuerySet, HP
 
     //call ws_sql to get row(s)
     sbErrors.set("HPCC_Conn:hpcc_exec : ");
-    if (!pHPCCdb->executeSQL(sqlQuery, targetQuerySet, sbErrors))
+    if (!pHPCCdb->executeSQL(sqlQuery, targetQuerySet, sbErrors, pStmtDA))
     {
         dam_addError(pStmtDA->pConnDA->dam_hdbc, pStmtDA->dam_hstmt, DAM_IP_ERROR, 0, (char *)sbErrors.str());
         return DAM_FAILURE;
@@ -137,4 +139,32 @@ int             hpcc_exec(const char * sqlQuery, const char * targetQuerySet, HP
     }
     tm_trace(hpcc_tm_Handle, UL_TM_F_TRACE, "HPCC_Conn:Read '%ld' rows\n", (*piNumRows));
     return DAM_SUCCESS;
+}
+
+
+/************************************************************************
+Function:       queryColumnDetails
+Description:    Get the table name
+************************************************************************/
+bool queryColumnDetails(/*input*/void *pStmtDA, /*input*/aindex_t colIdx,
+                        StringAttr &tblName, int * piColNum, int * piXOType, DAM_HCOL * phcol)
+{
+    aindex_t idx = 0;
+    DAM_HCOL hcol = dam_getFirstCol(((HPCC_STMT_DA*)pStmtDA)->dam_hstmt, DAM_COL_IN_USE);
+    while (hcol && idx < colIdx)
+    {
+        hcol = dam_getNextCol(((HPCC_STMT_DA*)pStmtDA)->dam_hstmt);
+        ++idx;
+    }
+
+    if (hcol && idx == colIdx)
+    {
+        char sColName[DAM_MAX_ID_LEN+1];
+        int colType;
+        dam_describeCol(hcol, piColNum, sColName, piXOType, &colType);
+        tblName.set(((HPCC_STMT_DA*)pStmtDA)->sTableName);
+        *phcol = hcol;
+        return true;
+    }
+    return false;
 }

--- a/src/hpcc_util.cpp
+++ b/src/hpcc_util.cpp
@@ -29,6 +29,9 @@ int hpcc_add_row(HPCC_STMT_DA *pStmtDA, DAM_HROW hrow, IPropertyTree * pRow, CCo
     int64           i64Val;
     double          dVal;
 
+    if (pCol->m_hcol == (DAM_HCOL)UNINITIALIZED)//Progress column doesnt exist. This happens on COUNT(*) and similar, so lets ignore it for now
+        return DAM_SUCCESS;
+
     const char * value = pRow->queryProp(pCol->m_alias);//Alias takes precedence over name
     if (NULL == value)
         value = pRow->queryProp(pCol->m_name);

--- a/src/hpcc_util.hpp
+++ b/src/hpcc_util.hpp
@@ -55,5 +55,7 @@ typedef struct hpcc_statement_struct
 extern TM_ModuleCB     hpcc_tm_Handle; /* declared in hpcc_drv.c */
 
 int     hpcc_exec(const char * sqlQuery, const char * targetQuerySet, HPCC_STMT_DA *pStmtDA, int *piNumResRows);
+bool    queryColumnDetails(/*input*/void *pStmtDA, /*input*/aindex_t ColIdx,
+                            StringAttr &tblName, int * piColNum, int * piXOType, DAM_HCOL * phcol);
 
 #endif  /* __HPCCUTIL_HPP */

--- a/src/hpccdb.cpp
+++ b/src/hpccdb.cpp
@@ -738,6 +738,7 @@ bool HPCCdb::executeSQL(const char * sql, const char * targetQuerySet, StringBuf
                                                     const char * pp = strchr(pHPCCType, ':');
                                                     outputColumn->m_hpccType.set(pp ? pp + 1 : pHPCCType);
                                                     outputColumn->m_iXOType = UNINITIALIZED;
+                                                    outputColumn->m_hcol = (DAM_HCOL)UNINITIALIZED;
                                                 }
                                                 populateOAtypes(outputColumn.get());//map HPCC data types to OpenAccess types
                                                 ++iColIdx;

--- a/src/hpccdb.hpp
+++ b/src/hpccdb.hpp
@@ -43,6 +43,18 @@ public:
     CColumn(const char * _name) : m_name(_name), m_iXOType(UNINITIALIZED) {}
     virtual ~CColumn()  {}
 
+    void copyFrom(CColumn * pFrom)
+    {
+        m_name.set(pFrom->m_name);
+        m_alias.set(pFrom->m_alias);
+        m_hpccType.set(pFrom->m_hpccType);
+
+        m_iXOType = pFrom->m_iXOType;
+        m_type_name.set(pFrom->m_type_name);
+        m_char_max_length = pFrom->m_char_max_length;
+        m_numeric_precision = pFrom->m_numeric_precision;
+        m_hcol = pFrom->m_hcol;
+    }
     //HPCC attributes, queried from wssql
     StringAttr      m_name;             // Column/dataElement name
     StringAttr      m_alias;            // sumout1, etc
@@ -264,7 +276,7 @@ public:
     //ws_sql calls
     bool        getHPCCDBSystemInfo();
     bool        getTableSchema(const char * _tableFilter, IArrayOf<CTable> &_tables);
-    bool        executeSQL(const char * sql, const char * targetQuerySet, StringBuffer & sbErrors);
+    bool        executeSQL(const char * sql, const char * targetQuerySet, StringBuffer & sbErrors, void *pStmtDA);
     bool        getMoreResults(const char * _wuid, const char * dsName, aindex_t _start, aindex_t _count, IPropertyTree ** _ppResultsTree, StringBuffer & _sbErrors);
     bool        executeStoredProcedure(const char * procName, const char * querySet);
 


### PR DESCRIPTION
Currently the connector queries Progress for the output column information
so it can build up its output schema cache. This is problematic when the
user specifies a scaler in their SELECT such as SELECT SUM(1) or SELECT
COUNT(*) since they are not treated as columns by Progress. This PR
changes the logic to delay the buildup of the output cache descriptors
until it came back from WsSQL/HPCC, and uses that schema information

Signed-off-by: Russ Whitehead <william.whitehead@lexisnexis.com>