### PR TITLE
ODBC-33 Release mode build fails due to debug code

### DIFF
--- a/src/hpcc_drv.cpp
+++ b/src/hpcc_drv.cpp
@@ -487,9 +487,7 @@ int             OAIP_execute(IP_HDBC hdbc,
         if (DAM_SUCCESS == iRetCode && szSqlBuffer[0])
             sqlBuff.set(szSqlBuffer);
     }
-#ifdef _DEBUG
     DUMP(sqlBuff.get());
-#endif
 
     //-----------------------------------
     //execute the SELECT query
@@ -639,9 +637,7 @@ int             OAIP_procedure(IP_HDBC hdbc, DAM_HSTMT hstmt, int iType, int *pi
     }
     if (iNumInputs)
         sqlBuff.append(");");
-#ifdef _DEBUG
     DUMP(sqlBuff.str());
-#endif
 
     //----------------------------------------------------------
     //Call HPCC to execute the stored procedure (Deployed Query)

--- a/src/hpcc_util.cpp
+++ b/src/hpcc_util.cpp
@@ -112,9 +112,7 @@ int             hpcc_exec(const char * sqlQuery, const char * targetQuerySet, HP
     bool bRowAvail = pHPCCdb->ReadFirstRow(&pRow);
     while (bRowAvail)
     {
-#ifdef _DEBUG
         DUMPPTREE(pRow);
-#endif
         hrow = dam_allocRow(pStmtDA->dam_hstmt);//allocate a new row
         aindex_t iNumColumns = pHPCCdb->queryOutputColumnDescriptorCount();
         for (aindex_t col = 0; col < iNumColumns; col++)//iterate over each column in this row

--- a/src/hpccdb.cpp
+++ b/src/hpccdb.cpp
@@ -616,17 +616,13 @@ bool HPCCdb::executeSQL(const char * sql, const char * targetQuerySet, StringBuf
     //-----------------
     const char * resultXML = resp->getResult();
 
-#ifdef _DEBUG
     DUMP(resultXML);
-#endif
     Owned<IPropertyTree> resultsTree;
     {
         Owned<IPTreeMaker> maker = createRootLessPTreeMaker(ipt_ordered);
         resultsTree.setown(createPTreeFromXMLString(resultXML, ipt_none, (PTreeReaderOptions)(ptr_noRoot | ptr_ignoreWhiteSpace), maker));
     }
-#ifdef _DEBUG
     DUMPPTREE(resultsTree);
-#endif
     Owned<IPropertyTreeIterator> datasetIterator;
     datasetIterator.setown(resultsTree->getElements("Dataset"));
     ForEach(*datasetIterator)
@@ -808,17 +804,13 @@ bool HPCCdb::getMoreResults(const char * _wuid, const char * _dsName, aindex_t _
     //-----------------
     const char * resultXML = resp->getResult();
 
-#ifdef _DEBUG
     DUMP(resultXML);
-#endif
     Owned<IPropertyTree> resultsTree;
     {
         Owned<IPTreeMaker> maker = createRootLessPTreeMaker();
         resultsTree.setown(createPTreeFromXMLString(resultXML, ipt_none, (PTreeReaderOptions)(ptr_noRoot | ptr_ignoreWhiteSpace), maker));
     }
-#ifdef _DEBUG
     DUMPPTREE(resultsTree);
-#endif
     Owned<IPropertyTreeIterator> datasetIterator;
     datasetIterator.setown(resultsTree->getElements("Dataset"));
     ForEach(*datasetIterator)

--- a/src/hpccdb.hpp
+++ b/src/hpccdb.hpp
@@ -28,6 +28,9 @@
 #ifdef _DEBUG
     #define DUMPPTREE(pt)   {StringBuffer sb;toXML(pt,sb);OutputDebugString("\n");OutputDebugString(sb.str());OutputDebugString("\n");}
     #define DUMP(s)         {OutputDebugString("\n");OutputDebugString(s);OutputDebugString("\n");}
+#else
+    #define DUMPPTREE(pt)   {}
+    #define DUMP(s)         {}
 #endif
 
 //---------------------------------------------


### PR DESCRIPTION
Some debug tracing was added recently ("DUMPTREE") that caused the
release build to break. This PR makes that trace code only enabled
during debug builds

Signed-off-by: Russ Whitehead william.whitehead@lexisnexis.com
